### PR TITLE
fix: Address Entity Model Defects

### DIFF
--- a/backend/src/main/java/com/jhub/backend/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/jhub/backend/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.jhub.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/jhub/backend/model/JobApplication.java
+++ b/backend/src/main/java/com/jhub/backend/model/JobApplication.java
@@ -1,7 +1,7 @@
 package com.jhub.backend.model;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -11,6 +11,9 @@ import com.jhub.backend.model.enums.JobApplicationStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * represents a job application tracked by a user
@@ -18,6 +21,7 @@ import lombok.*;
  */
 @Entity
 @Table(name = "job_applications")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,18 +31,20 @@ public class JobApplication {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     @NotBlank(message = "Company name is required")
+    @Size(max = 255, message = "Company name must not exceed 255 characters")
     private String company;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     @NotBlank(message = "Job title is required")
+    @Size(max = 255, message = "Job title must not exceed 255 characters")
     private String jobTitle;
 
     @Enumerated(EnumType.STRING)
@@ -48,12 +54,18 @@ public class JobApplication {
     @Column(nullable = false)
     private LocalDate dateApplied;
 
+    @Column(length = 2048)
+    @Size(max = 2048, message = "Job posting URL must not exceed 2048 characters")
     private String jobPostingUrl;
 
+    @Column(length = 255)
+    @Size(max = 255, message = "Location must not exceed 255 characters")
     private String location;
 
+    @Min(value = 0, message = "Minimum salary must not be negative")
     private Integer salaryMin;
 
+    @Min(value = 0, message = "Maximum salary must not be negative")
     private Integer salaryMax;
 
     @Column(columnDefinition = "TEXT")
@@ -66,11 +78,13 @@ public class JobApplication {
     )
     private List<Note> notes = new ArrayList<>();
 
+    @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @Builder
     public JobApplication(
@@ -95,18 +109,6 @@ public class JobApplication {
         this.salaryMin = salaryMin;
         this.salaryMax = salaryMax;
         this.description = description;
-    }
-
-    @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void addNote(Note note) {

--- a/backend/src/main/java/com/jhub/backend/model/Note.java
+++ b/backend/src/main/java/com/jhub/backend/model/Note.java
@@ -2,16 +2,20 @@ package com.jhub.backend.model;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * represents a timestamped note on a job application
  */
 @Entity
 @Table(name = "notes")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,7 +25,7 @@ public class Note {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_application_id", nullable = false)
@@ -36,11 +40,13 @@ public class Note {
 
     private LocalDate followUpDate;
 
+    @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @Builder
     public Note(
@@ -53,17 +59,5 @@ public class Note {
         this.content = content;
         this.followUp = followUp;
         this.followUpDate = followUpDate;
-    }
-
-    @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/jhub/backend/model/User.java
+++ b/backend/src/main/java/com/jhub/backend/model/User.java
@@ -1,6 +1,6 @@
 package com.jhub.backend.model;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -8,6 +8,9 @@ import java.util.UUID;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * user entity representing an application user
@@ -15,6 +18,7 @@ import lombok.*;
  */
 @Entity
 @Table(name = "users") // "user" is a reserved word in PostgreSQL, so we use "users"
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,31 +28,36 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    private UUID id = UUID.randomUUID();
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, length = 255)
     @Email(message = "Email must be a valid email address")
     @NotBlank(message = "Email is required")
+    @Size(max = 255, message = "Email must not exceed 255 characters")
     private String email;
 
     @Column(nullable = false)
     @NotBlank(message = "Password is required")
-    @Size(min = 8, message = "Password must be at least 8 characters")
+    @Size(min = 8, max = 255, message = "Password must be between 8 and 255 characters")
     private String password; // will be hashed by the service layer
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     @NotBlank(message = "First name is required")
+    @Size(max = 100, message = "First name must not exceed 100 characters")
     private String firstName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     @NotBlank(message = "Last name is required")
+    @Size(max = 100, message = "Last name must not exceed 100 characters")
     private String lastName;
 
+    @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @OneToMany(
         mappedBy = "user",
@@ -68,18 +77,6 @@ public class User {
         this.password = password;
         this.firstName = firstName;
         this.lastName = lastName;
-    }
-
-    @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void addJobApplication(JobApplication jobApplication) {


### PR DESCRIPTION
## Summary
- Initializes UUID at field declaration (`UUID.randomUUID()`) so `equals`/`hashCode` work correctly for unpersisted entities
- Adds `@Column(length=...)` and `@Size(max=...)` constraints on all string fields; increases `jobPostingUrl` column to 2048 chars to support long URLs
- Adds `@Min(0)` validation on `salaryMin` and `salaryMax` to prevent negative values
- Replaces manual `@PrePersist`/`@PreUpdate` lifecycle callbacks with Spring Data JPA auditing (`@CreatedDate`/`@LastModifiedDate`) using `Instant` instead of `LocalDateTime` for timezone safety
- Creates `JpaAuditingConfig` with `@EnableJpaAuditing`
- Defers moving validation annotations from entities to DTOs until #34/#40

Closes #47