### PR TITLE
chore: Upgrade to Spring Boot 4.0.2 and Testcontainers 2.0.3

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	java
-	id("org.springframework.boot") version "3.5.6"
+	id("org.springframework.boot") version "4.0.2"
 	id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -31,8 +31,8 @@ dependencies {
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
-	testImplementation("org.testcontainers:junit-jupiter")
-	testImplementation("org.testcontainers:postgresql")
+	testImplementation("org.testcontainers:testcontainers-junit-jupiter")
+	testImplementation("org.testcontainers:testcontainers-postgresql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	// lombok for tests

--- a/backend/src/test/java/com/jhub/backend/config/TestContainersConfig.java
+++ b/backend/src/test/java/com/jhub/backend/config/TestContainersConfig.java
@@ -2,7 +2,7 @@ package com.jhub.backend.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 
 @TestConfiguration
@@ -10,7 +10,7 @@ public class TestContainersConfig {
 
 	@Container
 	@ServiceConnection
-	static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18-alpine")
+	static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:18-alpine")
 			.withDatabaseName("testdb")
 			.withUsername("test")
 			.withPassword("test");


### PR DESCRIPTION
## Summary

* Resolves Docker API version incompatibility caused by Docker Desktop 29.2.0 raising the minimum API version from 1.24 to 1.44. 
* Updates Testcontainers to 2.0.3 (via docker-java 3.7.0) which properly negotiates the API version, eliminating the docker-java.properties workaround for local WSL 2 development.

Closes #53 