### PR TITLE
feat: Add Global Error Handling and Notifications

### DIFF
--- a/frontend/src/components/__tests__/errors.test.tsx
+++ b/frontend/src/components/__tests__/errors.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { ErrorFallback } from '../errors/ErrorFallback';
+import { NotFound } from '../errors/NotFound';
+import { useAuthStore } from '@/stores/authStore';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...props }: Record<string, unknown>) =>
+    createElement('a', { href: to as string, ...props }, children as ReactNode),
+}));
+
+describe('ErrorFallback', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the error heading with an alert role', () => {
+    render(<ErrorFallback error={new Error('kaboom')} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('shows a Try again button that calls reset when provided', () => {
+    const reset = vi.fn();
+    render(<ErrorFallback error={new Error('kaboom')} reset={reset} />);
+    fireEvent.click(screen.getByText('Try again'));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the Try again button when no reset is provided', () => {
+    render(<ErrorFallback error={new Error('kaboom')} />);
+    expect(screen.queryByText('Try again')).not.toBeInTheDocument();
+  });
+});
+
+describe('NotFound', () => {
+  beforeEach(() => {
+    cleanup();
+    useAuthStore.setState({ user: null, accessToken: null });
+  });
+
+  it('links to login when signed out', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Go to Login').closest('a')).toHaveAttribute('href', '/login');
+  });
+
+  it('links to dashboard when signed in', () => {
+    useAuthStore.setState({
+      user: {
+        id: '1',
+        email: 'a@b.com',
+        firstName: 'A',
+        lastName: 'B',
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+    render(<NotFound />);
+    expect(screen.getByText('Go to Dashboard').closest('a')).toHaveAttribute('href', '/dashboard');
+  });
+});

--- a/frontend/src/components/errors/ErrorBoundary.tsx
+++ b/frontend/src/components/errors/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { ErrorFallback } from '@/components/errors/ErrorFallback';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Top-level class boundary wrapping the RouterProvider. Catches render errors
+ * that occur outside the router tree (e.g. a provider throwing during render),
+ * which the router's own `errorComponent` cannot reach.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (import.meta.env.DEV) {
+      console.error('Uncaught error:', error, info.componentStack);
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return <ErrorFallback error={this.state.error} reset={this.reset} />;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/errors/ErrorFallback.tsx
+++ b/frontend/src/components/errors/ErrorFallback.tsx
@@ -1,0 +1,46 @@
+import { TriangleAlertIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface ErrorFallbackProps {
+  error: Error;
+  /** Clears the error and re-attempts rendering. Provided by the router or boundary. */
+  reset?: () => void;
+}
+
+/**
+ * Shared fallback shown when a render or route error is caught. Rendered by the
+ * TanStack Router root `errorComponent` and by the top-level ErrorBoundary.
+ */
+export function ErrorFallback({ error, reset }: ErrorFallbackProps) {
+  return (
+    <main
+      className="flex min-h-screen flex-col items-center justify-center p-4"
+      role="alert"
+      aria-labelledby="error-heading"
+    >
+      <Card className="w-full max-w-md text-center">
+        <CardHeader>
+          <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <TriangleAlertIcon className="size-6" />
+          </div>
+          <CardTitle id="error-heading">Something went wrong</CardTitle>
+          <CardDescription>An unexpected error occurred while loading this page.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {import.meta.env.DEV && error?.message ? (
+            <pre className="text-muted-foreground max-h-32 overflow-auto rounded-md bg-muted p-3 text-left text-xs">
+              {error.message}
+            </pre>
+          ) : null}
+          <div className="flex justify-center gap-2">
+            {reset ? <Button onClick={reset}>Try again</Button> : null}
+            <Button variant="outline" onClick={() => window.location.assign('/')}>
+              Go home
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/frontend/src/components/errors/NotFound.tsx
+++ b/frontend/src/components/errors/NotFound.tsx
@@ -1,0 +1,28 @@
+import { Link } from '@tanstack/react-router';
+import { useAuthStore } from '@/stores/authStore';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Shared 404 view used by the catch-all route (`$.tsx`) for unmatched URLs and
+ * by the root `notFoundComponent` for programmatic `notFound()` throws.
+ */
+export function NotFound() {
+  const user = useAuthStore((s) => s.user);
+  const linkTo = user ? '/dashboard' : '/login';
+  const linkLabel = user ? 'Go to Dashboard' : 'Go to Login';
+
+  return (
+    <main
+      className="flex min-h-screen flex-col items-center justify-center gap-4"
+      aria-labelledby="not-found-heading"
+    >
+      <h1 id="not-found-heading" className="text-4xl font-bold">
+        404
+      </h1>
+      <p className="text-muted-foreground">Page not found</p>
+      <Button asChild>
+        <Link to={linkTo}>{linkLabel}</Link>
+      </Button>
+    </main>
+  );
+}

--- a/frontend/src/lib/__tests__/notifications.test.ts
+++ b/frontend/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveErrorMessage, notify } from '../notifications';
+import { ApiError } from '@/lib/api';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+describe('resolveErrorMessage', () => {
+  it('returns a generic permission message for 403', () => {
+    expect(resolveErrorMessage(new ApiError(403, null))).toBe(
+      'You do not have permission to perform this action.'
+    );
+  });
+
+  it('returns a generic server message for 5xx', () => {
+    expect(resolveErrorMessage(new ApiError(500, null))).toBe(
+      'Something went wrong on our end. Please try again shortly.'
+    );
+    expect(resolveErrorMessage(new ApiError(503, null))).toBe(
+      'Something went wrong on our end. Please try again shortly.'
+    );
+  });
+
+  it('surfaces the backend message for 4xx', () => {
+    const body = {
+      timestamp: '',
+      status: 400,
+      error: 'Bad Request',
+      message: 'Company is required',
+      path: '/api/job-applications',
+      fieldErrors: null,
+    };
+    expect(resolveErrorMessage(new ApiError(400, body))).toBe('Company is required');
+  });
+
+  it('returns a network message for TypeError', () => {
+    expect(resolveErrorMessage(new TypeError('Failed to fetch'))).toBe(
+      'Network error. Check your connection and try again.'
+    );
+  });
+
+  it('falls back to the error message for a plain Error', () => {
+    expect(resolveErrorMessage(new Error('Boom'))).toBe('Boom');
+  });
+
+  it('falls back to a generic message for unknown values', () => {
+    expect(resolveErrorMessage('nope')).toBe('An unexpected error occurred. Please try again.');
+    expect(resolveErrorMessage(new Error(''))).toBe(
+      'An unexpected error occurred. Please try again.'
+    );
+  });
+});
+
+describe('notify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('de-duplicates error toasts by message id', async () => {
+    const { toast } = await import('sonner');
+    notify.error(new ApiError(403, null));
+    expect(toast.error).toHaveBeenCalledWith('You do not have permission to perform this action.', {
+      id: 'error:You do not have permission to perform this action.',
+    });
+  });
+
+  it('forwards success and info messages', async () => {
+    const { toast } = await import('sonner');
+    notify.success('Saved');
+    notify.info('Heads up');
+    expect(toast.success).toHaveBeenCalledWith('Saved');
+    expect(toast.info).toHaveBeenCalledWith('Heads up');
+  });
+});

--- a/frontend/src/lib/__tests__/queryClient.test.ts
+++ b/frontend/src/lib/__tests__/queryClient.test.ts
@@ -63,6 +63,15 @@ describe('createAppQueryClient', () => {
     expect(toast.error).toHaveBeenCalledWith('Mutation failed', expect.objectContaining({}));
   });
 
+  it('does not toast mutation 401 errors (handled by auth flow)', async () => {
+    const { toast } = await import('sonner');
+    const client = createAppQueryClient();
+    const onError = client.getDefaultOptions().mutations?.onError;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (onError as any)?.(new ApiError(401, null));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it('surfaces query errors as toasts via the query cache', async () => {
     const { toast } = await import('sonner');
     const client = createAppQueryClient();

--- a/frontend/src/lib/__tests__/queryClient.test.ts
+++ b/frontend/src/lib/__tests__/queryClient.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createAppQueryClient } from '../queryClient';
 import { ApiError } from '@/lib/api';
 
 vi.mock('sonner', () => ({
   toast: {
     error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
   },
 }));
 
 describe('createAppQueryClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('sets default staleTime to 5 minutes', () => {
     const client = createAppQueryClient();
     const defaults = client.getDefaultOptions();
@@ -54,6 +60,25 @@ describe('createAppQueryClient', () => {
     const error = new Error('Mutation failed');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (onError as any)?.(error);
-    expect(toast.error).toHaveBeenCalledWith('Mutation failed');
+    expect(toast.error).toHaveBeenCalledWith('Mutation failed', expect.objectContaining({}));
+  });
+
+  it('surfaces query errors as toasts via the query cache', async () => {
+    const { toast } = await import('sonner');
+    const client = createAppQueryClient();
+    const onError = client.getQueryCache().config.onError;
+    onError?.(new ApiError(500, null), {} as never);
+    expect(toast.error).toHaveBeenCalledWith(
+      'Something went wrong on our end. Please try again shortly.',
+      expect.objectContaining({})
+    );
+  });
+
+  it('does not toast query 401 errors (handled by auth flow)', async () => {
+    const { toast } = await import('sonner');
+    const client = createAppQueryClient();
+    const onError = client.getQueryCache().config.onError;
+    onError?.(new ApiError(401, null), {} as never);
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,45 @@
+import { toast } from 'sonner';
+import { ApiError } from '@/lib/api';
+
+/**
+ * Maps any thrown value to a user-facing message. Backend-provided messages
+ * (validation, not-found, etc.) are surfaced as-is for 4xx, while 403 and 5xx
+ * get friendly, generic copy so we never leak server internals to the user.
+ */
+export function resolveErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 403) {
+      return 'You do not have permission to perform this action.';
+    }
+    if (error.status >= 500) {
+      return 'Something went wrong on our end. Please try again shortly.';
+    }
+    return error.message;
+  }
+  // fetch throws a TypeError when the network is unreachable.
+  if (error instanceof TypeError) {
+    return 'Network error. Check your connection and try again.';
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return 'An unexpected error occurred. Please try again.';
+}
+
+/**
+ * Centralized toast helpers so feature code never calls `sonner` directly.
+ * Error toasts are de-duplicated by message, preventing spam when several
+ * queries or mutations fail with the same underlying cause at once.
+ */
+export const notify = {
+  success(message: string): void {
+    toast.success(message);
+  },
+  info(message: string): void {
+    toast.info(message);
+  },
+  error(error: unknown): void {
+    const message = resolveErrorMessage(error);
+    toast.error(message, { id: `error:${message}` });
+  },
+};

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,9 +1,22 @@
-import { QueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
+import { QueryCache, QueryClient } from '@tanstack/react-query';
 import { ApiError } from '@/lib/api';
+import { notify } from '@/lib/notifications';
 
 export function createAppQueryClient(): QueryClient {
   return new QueryClient({
+    // Surface query failures as toasts globally. Mutations toast via
+    // `mutations.onError`; queries need a QueryCache handler since their
+    // errors are otherwise swallowed unless a component reads them.
+    queryCache: new QueryCache({
+      onError(error) {
+        // 401 is handled by the auth refresh/logout flow — a toast here would
+        // be redundant noise during a session expiry.
+        if (error instanceof ApiError && error.status === 401) {
+          return;
+        }
+        notify.error(error);
+      },
+    }),
     defaultOptions: {
       queries: {
         staleTime: 5 * 60 * 1000,
@@ -16,7 +29,7 @@ export function createAppQueryClient(): QueryClient {
       },
       mutations: {
         onError(error) {
-          toast.error(error instanceof Error ? error.message : 'An error occurred');
+          notify.error(error);
         },
       },
     },

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -29,6 +29,11 @@ export function createAppQueryClient(): QueryClient {
       },
       mutations: {
         onError(error) {
+          // 401 is handled by the auth refresh/logout flow — a toast here would
+          // be redundant noise during a session expiry.
+          if (error instanceof ApiError && error.status === 401) {
+            return;
+          }
           notify.error(error);
         },
       },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { createRouter, RouterProvider } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
 import { authApi } from '@/lib/api';
+import { ErrorBoundary } from '@/components/errors/ErrorBoundary';
 import './index.css';
 
 const router = createRouter({ routeTree });
@@ -18,7 +19,9 @@ declare module '@tanstack/react-router' {
 authApi.refresh().finally(() => {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
-      <RouterProvider router={router} />
+      <ErrorBoundary>
+        <RouterProvider router={router} />
+      </ErrorBoundary>
     </StrictMode>
   );
 });

--- a/frontend/src/routes/$.tsx
+++ b/frontend/src/routes/$.tsx
@@ -1,28 +1,6 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { useAuthStore } from '@/stores/authStore';
-import { Button } from '@/components/ui/button';
+import { createFileRoute } from '@tanstack/react-router';
+import { NotFound } from '@/components/errors/NotFound';
 
 export const Route = createFileRoute('/$')({
   component: NotFound,
 });
-
-function NotFound() {
-  const user = useAuthStore((s) => s.user);
-  const linkTo = user ? '/dashboard' : '/login';
-  const linkLabel = user ? 'Go to Dashboard' : 'Go to Login';
-
-  return (
-    <main
-      className="flex min-h-screen flex-col items-center justify-center gap-4"
-      aria-labelledby="not-found-heading"
-    >
-      <h1 id="not-found-heading" className="text-4xl font-bold">
-        404
-      </h1>
-      <p className="text-muted-foreground">Page not found</p>
-      <Button asChild>
-        <Link to={linkTo}>{linkLabel}</Link>
-      </Button>
-    </main>
-  );
-}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,9 +1,11 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router';
+import { createRootRoute, Outlet, type ErrorComponentProps } from '@tanstack/react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
 import { createAppQueryClient } from '@/lib/queryClient';
 import { AuthProvider } from '@/providers/AuthProvider';
 import { Toaster } from '@/components/ui/sonner';
+import { ErrorFallback } from '@/components/errors/ErrorFallback';
+import { NotFound } from '@/components/errors/NotFound';
 
 const queryClient = createAppQueryClient();
 
@@ -18,4 +20,8 @@ export const Route = createRootRoute({
       </QueryClientProvider>
     </ThemeProvider>
   ),
+  errorComponent: ({ error, reset }: ErrorComponentProps) => (
+    <ErrorFallback error={error} reset={reset} />
+  ),
+  notFoundComponent: NotFound,
 });


### PR DESCRIPTION
Closes #84.

Fills the remaining gaps in frontend error handling. The 401 → refresh → retry → logout flow and the global Toaster were already in place; this adds the missing error boundary, query-error surfacing, and a centralized notification helper.

## Changes

- **Global error boundary** — a top-level `ErrorBoundary` class wraps `RouterProvider` (catches render errors outside the router tree), and the root route now defines `errorComponent`, both rendering a shared `ErrorFallback` with a "Try again" / "Go home" recovery action.
- **Query error surfacing** — added `QueryCache.onError` so failed queries now raise a toast instead of failing silently. `401` is skipped (handled by the auth refresh/logout flow).
- **Centralized notifications** — new `lib/notifications.ts` exposes `notify.{success,info,error}` and `resolveErrorMessage`. Both queries and mutations route through it. Error toasts are de-duplicated by message id to avoid spam.
- **Consistent messaging** — `403` → "You do not have permission…", `5xx` → generic "our end" copy (no leaked server internals), `4xx` → backend-provided message, network `TypeError` → "check your connection".
- **404** — extracted the not-found UI into a shared `NotFound` component, reused by the catch-all route and the root `notFoundComponent`.

## Verification

- `bun run test` — 140 passing (added notifications, query-cache, and error-component tests)
- `tsc -b`, `bun run lint`, `bun run build` — all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-screen error recovery screens with options to retry or return home.
  * Added user-aware 404 navigation to the dashboard or login page.
  * Added global error handling for unexpected application failures.
  * Standardized success, informational, and error notifications with clearer messages and duplicate prevention.

* **Bug Fixes**
  * Improved query and mutation error notifications while excluding authentication-related errors.

* **Tests**
  * Added coverage for error pages, notifications, and query error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->