### PR TITLE
feat: Add Notes Service and API

### DIFF
--- a/backend/src/main/java/com/jhub/backend/controller/NoteController.java
+++ b/backend/src/main/java/com/jhub/backend/controller/NoteController.java
@@ -1,0 +1,48 @@
+package com.jhub.backend.controller;
+
+import com.jhub.backend.dto.NoteCreateRequest;
+import com.jhub.backend.dto.NoteResponse;
+import com.jhub.backend.security.JwtSubjectParser;
+import com.jhub.backend.service.NoteService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notes")
+public class NoteController {
+
+  private final NoteService noteService;
+
+  public NoteController(NoteService noteService) {
+    this.noteService = noteService;
+  }
+
+  @PostMapping
+  public ResponseEntity<NoteResponse> create(
+      @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody NoteCreateRequest request) {
+    UUID userId = JwtSubjectParser.parseUserId(jwt);
+    NoteResponse response = noteService.createNote(userId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @GetMapping("/job-application/{jobApplicationId}")
+  public ResponseEntity<List<NoteResponse>> getForJobApplication(
+      @AuthenticationPrincipal Jwt jwt, @PathVariable UUID jobApplicationId) {
+    UUID userId = JwtSubjectParser.parseUserId(jwt);
+    List<NoteResponse> responses = noteService.getNotesForJobApplication(userId, jobApplicationId);
+    return ResponseEntity.ok(responses);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id) {
+    UUID userId = JwtSubjectParser.parseUserId(jwt);
+    noteService.deleteNote(userId, id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/jhub/backend/dto/NoteCreateRequest.java
+++ b/backend/src/main/java/com/jhub/backend/dto/NoteCreateRequest.java
@@ -1,0 +1,19 @@
+package com.jhub.backend.dto;
+
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record NoteCreateRequest(
+    @NotNull(message = "Job application id is required") UUID jobApplicationId,
+    @NotBlank(message = "Note content is required")
+        @Size(max = 10000, message = "Note content must not exceed 10000 characters")
+        String content,
+    boolean followUp,
+    LocalDate followUpDate) {
+
+  @AssertTrue(message = "Follow-up date requires followUp to be true")
+  private boolean isFollowUpDateConsistent() {
+    return followUpDate == null || followUp;
+  }
+}

--- a/backend/src/main/java/com/jhub/backend/dto/NoteResponse.java
+++ b/backend/src/main/java/com/jhub/backend/dto/NoteResponse.java
@@ -1,0 +1,26 @@
+package com.jhub.backend.dto;
+
+import com.jhub.backend.model.Note;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record NoteResponse(
+    UUID id,
+    UUID jobApplicationId,
+    String content,
+    boolean followUp,
+    LocalDate followUpDate,
+    Instant createdAt,
+    Instant updatedAt) {
+  public static NoteResponse from(Note entity) {
+    return new NoteResponse(
+        entity.getId(),
+        entity.getJobApplication().getId(),
+        entity.getContent(),
+        entity.isFollowUp(),
+        entity.getFollowUpDate(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/jhub/backend/repository/NoteRepository.java
+++ b/backend/src/main/java/com/jhub/backend/repository/NoteRepository.java
@@ -1,0 +1,28 @@
+package com.jhub.backend.repository;
+
+import com.jhub.backend.model.Note;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoteRepository extends JpaRepository<Note, UUID> {
+
+  List<Note> findByJobApplicationIdOrderByCreatedAtDesc(UUID jobApplicationId);
+
+  /** Follow-up notes for a user due within a date range, soonest first (dashboard). */
+  @Query(
+      """
+      select n from Note n
+      where n.jobApplication.user.id = :userId
+        and n.followUp = true
+        and n.followUpDate between :from and :to
+      order by n.followUpDate asc
+      """)
+  List<Note> findFollowUpsDueBetween(
+      @Param("userId") UUID userId, @Param("from") LocalDate from, @Param("to") LocalDate to);
+}

--- a/backend/src/main/java/com/jhub/backend/service/NoteService.java
+++ b/backend/src/main/java/com/jhub/backend/service/NoteService.java
@@ -1,0 +1,81 @@
+package com.jhub.backend.service;
+
+import com.jhub.backend.dto.NoteCreateRequest;
+import com.jhub.backend.dto.NoteResponse;
+import com.jhub.backend.exception.ResourceNotFoundException;
+import com.jhub.backend.model.JobApplication;
+import com.jhub.backend.model.Note;
+import com.jhub.backend.repository.JobApplicationRepository;
+import com.jhub.backend.repository.NoteRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class NoteService {
+
+  private final NoteRepository noteRepository;
+  private final JobApplicationRepository jobApplicationRepository;
+
+  public NoteService(
+      NoteRepository noteRepository, JobApplicationRepository jobApplicationRepository) {
+    this.noteRepository = noteRepository;
+    this.jobApplicationRepository = jobApplicationRepository;
+  }
+
+  public List<NoteResponse> getNotesForJobApplication(UUID userId, UUID jobApplicationId) {
+    findJobApplicationAndVerifyOwnership(userId, jobApplicationId);
+    return noteRepository.findByJobApplicationIdOrderByCreatedAtDesc(jobApplicationId).stream()
+        .map(NoteResponse::from)
+        .toList();
+  }
+
+  @Transactional
+  public NoteResponse createNote(UUID userId, NoteCreateRequest request) {
+    JobApplication application =
+        findJobApplicationAndVerifyOwnership(userId, request.jobApplicationId());
+
+    Note note =
+        Note.builder()
+            .content(request.content())
+            .followUp(request.followUp())
+            .followUpDate(request.followUpDate())
+            .build();
+
+    application.addNote(note);
+    Note saved = noteRepository.save(note);
+    return NoteResponse.from(saved);
+  }
+
+  @Transactional
+  public void deleteNote(UUID userId, UUID noteId) {
+    Note note =
+        noteRepository
+            .findById(noteId)
+            .orElseThrow(() -> new ResourceNotFoundException("Note", "id", noteId));
+
+    // Not-owned resources are reported as 404 (not 403) so their existence
+    // is never revealed to other accounts, matching JobApplicationService.
+    if (!note.getJobApplication().getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("Note", "id", noteId);
+    }
+
+    note.getJobApplication().removeNote(note);
+  }
+
+  private JobApplication findJobApplicationAndVerifyOwnership(UUID userId, UUID jobApplicationId) {
+    JobApplication application =
+        jobApplicationRepository
+            .findById(jobApplicationId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException("JobApplication", "id", jobApplicationId));
+
+    if (!application.getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("JobApplication", "id", jobApplicationId);
+    }
+
+    return application;
+  }
+}

--- a/backend/src/test/java/com/jhub/backend/controller/NoteControllerTest.java
+++ b/backend/src/test/java/com/jhub/backend/controller/NoteControllerTest.java
@@ -1,0 +1,196 @@
+package com.jhub.backend.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.jhub.backend.dto.NoteCreateRequest;
+import com.jhub.backend.dto.NoteResponse;
+import com.jhub.backend.exception.GlobalExceptionHandler;
+import com.jhub.backend.exception.ResourceNotFoundException;
+import com.jhub.backend.service.NoteService;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class NoteControllerTest {
+
+  private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final UUID APP_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+  private static final UUID NOTE_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+  private MockMvc mockMvc;
+  private ObjectMapper objectMapper;
+
+  @Mock private NoteService noteService;
+
+  @InjectMocks private NoteController noteController;
+
+  @BeforeEach
+  void setUp() {
+    JacksonJsonHttpMessageConverter jacksonConverter = new JacksonJsonHttpMessageConverter();
+    objectMapper = jacksonConverter.getMapper();
+
+    Jwt jwt =
+        new Jwt(
+            "mock-token",
+            Instant.now(),
+            Instant.now().plusSeconds(3600),
+            Map.of("alg", "RS256"),
+            Map.of("sub", USER_ID.toString()));
+
+    var authentication = new TestingAuthenticationToken(jwt, null, "ROLE_USER");
+    var securityContext = new SecurityContextImpl(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(noteController)
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .setMessageConverters(jacksonConverter)
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build();
+  }
+
+  private NoteResponse sampleResponse() {
+    return new NoteResponse(
+        NOTE_ID,
+        APP_ID,
+        "Spoke with recruiter",
+        true,
+        LocalDate.of(2026, 8, 1),
+        Instant.now(),
+        Instant.now());
+  }
+
+  @Test
+  void createReturnsCreatedWithResponseBody() throws Exception {
+    NoteCreateRequest request =
+        new NoteCreateRequest(APP_ID, "Spoke with recruiter", true, LocalDate.of(2026, 8, 1));
+    when(noteService.createNote(eq(USER_ID), any())).thenReturn(sampleResponse());
+
+    mockMvc
+        .perform(
+            post("/api/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(NOTE_ID.toString()))
+        .andExpect(jsonPath("$.jobApplicationId").value(APP_ID.toString()))
+        .andExpect(jsonPath("$.content").value("Spoke with recruiter"))
+        .andExpect(jsonPath("$.followUp").value(true));
+  }
+
+  @Test
+  void createReturnsBadRequestForBlankContent() throws Exception {
+    String invalidJson =
+        """
+        {"jobApplicationId":"%s","content":"  ","followUp":false}
+        """
+            .formatted(APP_ID);
+
+    mockMvc
+        .perform(post("/api/notes").contentType(MediaType.APPLICATION_JSON).content(invalidJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Validation failed"))
+        .andExpect(jsonPath("$.fieldErrors.content").exists());
+  }
+
+  @Test
+  void createReturnsBadRequestForMissingJobApplicationId() throws Exception {
+    String invalidJson =
+        """
+        {"content":"A note","followUp":false}
+        """;
+
+    mockMvc
+        .perform(post("/api/notes").contentType(MediaType.APPLICATION_JSON).content(invalidJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.fieldErrors.jobApplicationId").exists());
+  }
+
+  @Test
+  void createReturnsBadRequestForFollowUpDateWithoutFlag() throws Exception {
+    String invalidJson =
+        """
+        {"jobApplicationId":"%s","content":"A note","followUp":false,"followUpDate":"2026-08-01"}
+        """
+            .formatted(APP_ID);
+
+    mockMvc
+        .perform(post("/api/notes").contentType(MediaType.APPLICATION_JSON).content(invalidJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("Validation failed"));
+  }
+
+  @Test
+  void createReturnsNotFoundForUnownedApplication() throws Exception {
+    NoteCreateRequest request = new NoteCreateRequest(APP_ID, "A note", false, null);
+    when(noteService.createNote(eq(USER_ID), any()))
+        .thenThrow(new ResourceNotFoundException("JobApplication", "id", APP_ID));
+
+    mockMvc
+        .perform(
+            post("/api/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getForJobApplicationReturnsOkWithList() throws Exception {
+    when(noteService.getNotesForJobApplication(USER_ID, APP_ID))
+        .thenReturn(List.of(sampleResponse()));
+
+    mockMvc
+        .perform(get("/api/notes/job-application/{id}", APP_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(NOTE_ID.toString()))
+        .andExpect(jsonPath("$[0].content").value("Spoke with recruiter"));
+  }
+
+  @Test
+  void getForJobApplicationReturnsNotFoundWhenUnowned() throws Exception {
+    when(noteService.getNotesForJobApplication(USER_ID, APP_ID))
+        .thenThrow(new ResourceNotFoundException("JobApplication", "id", APP_ID));
+
+    mockMvc
+        .perform(get("/api/notes/job-application/{id}", APP_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteReturnsNoContent() throws Exception {
+    mockMvc.perform(delete("/api/notes/{id}", NOTE_ID)).andExpect(status().isNoContent());
+  }
+
+  @Test
+  void deleteReturnsNotFoundWhenUnowned() throws Exception {
+    doThrow(new ResourceNotFoundException("Note", "id", NOTE_ID))
+        .when(noteService)
+        .deleteNote(USER_ID, NOTE_ID);
+
+    mockMvc.perform(delete("/api/notes/{id}", NOTE_ID)).andExpect(status().isNotFound());
+  }
+}

--- a/backend/src/test/java/com/jhub/backend/repository/NoteRepositoryTest.java
+++ b/backend/src/test/java/com/jhub/backend/repository/NoteRepositoryTest.java
@@ -1,0 +1,142 @@
+package com.jhub.backend.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jhub.backend.config.TestContainersConfig;
+import com.jhub.backend.model.JobApplication;
+import com.jhub.backend.model.Note;
+import com.jhub.backend.model.User;
+import com.jhub.backend.model.enums.JobApplicationStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.context.ImportTestcontainers;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ImportTestcontainers(TestContainersConfig.class)
+@Transactional
+@ActiveProfiles("test")
+class NoteRepositoryTest {
+
+  @Autowired private NoteRepository noteRepository;
+
+  @PersistenceContext private EntityManager entityManager;
+
+  private User user1;
+  private User user2;
+  private JobApplication app1;
+  private JobApplication app2;
+
+  @BeforeEach
+  void setUp() {
+    user1 =
+        User.builder()
+            .email("user1@example.com")
+            .password("password123")
+            .firstName("User")
+            .lastName("One")
+            .build();
+    entityManager.persist(user1);
+
+    user2 =
+        User.builder()
+            .email("user2@example.com")
+            .password("password123")
+            .firstName("User")
+            .lastName("Two")
+            .build();
+    entityManager.persist(user2);
+
+    app1 =
+        JobApplication.builder()
+            .company("Company A")
+            .jobTitle("Developer")
+            .status(JobApplicationStatus.APPLIED)
+            .dateApplied(LocalDate.of(2026, 1, 10))
+            .build();
+    user1.addJobApplication(app1);
+    entityManager.persist(app1);
+
+    app2 =
+        JobApplication.builder()
+            .company("Company B")
+            .jobTitle("Engineer")
+            .status(JobApplicationStatus.INTERVIEWING)
+            .dateApplied(LocalDate.of(2026, 1, 15))
+            .build();
+    user2.addJobApplication(app2);
+    entityManager.persist(app2);
+
+    persistNote(app1, "First note", false, null);
+    persistNote(app1, "Follow up with recruiter", true, LocalDate.of(2026, 7, 20));
+    persistNote(app1, "Follow up far out", true, LocalDate.of(2026, 12, 1));
+    persistNote(app2, "Other user's follow-up", true, LocalDate.of(2026, 7, 21));
+
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  private void persistNote(
+      JobApplication application, String content, boolean followUp, LocalDate followUpDate) {
+    Note note =
+        Note.builder().content(content).followUp(followUp).followUpDate(followUpDate).build();
+    application.addNote(note);
+    entityManager.persist(note);
+  }
+
+  @Test
+  void findByJobApplicationId_returnsOnlyThatApplicationsNotes() {
+    List<Note> notes = noteRepository.findByJobApplicationIdOrderByCreatedAtDesc(app1.getId());
+
+    assertThat(notes).hasSize(3);
+    assertThat(notes).extracting(Note::getContent).doesNotContain("Other user's follow-up");
+  }
+
+  @Test
+  void findFollowUpsDueBetween_returnsOnlyFollowUpsInRangeForUser() {
+    List<Note> followUps =
+        noteRepository.findFollowUpsDueBetween(
+            user1.getId(), LocalDate.of(2026, 7, 14), LocalDate.of(2026, 7, 31));
+
+    assertThat(followUps).hasSize(1);
+    assertThat(followUps.getFirst().getContent()).isEqualTo("Follow up with recruiter");
+  }
+
+  @Test
+  void findFollowUpsDueBetween_excludesOtherUsersFollowUps() {
+    List<Note> followUps =
+        noteRepository.findFollowUpsDueBetween(
+            user1.getId(), LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31));
+
+    assertThat(followUps).extracting(Note::getContent).doesNotContain("Other user's follow-up");
+  }
+
+  @Test
+  void findFollowUpsDueBetween_ordersBySoonestFirst() {
+    List<Note> followUps =
+        noteRepository.findFollowUpsDueBetween(
+            user1.getId(), LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31));
+
+    assertThat(followUps).hasSize(2);
+    assertThat(followUps.getFirst().getFollowUpDate()).isEqualTo(LocalDate.of(2026, 7, 20));
+    assertThat(followUps.getLast().getFollowUpDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+  }
+
+  @Test
+  void deletingNoteViaOrphanRemoval_removesRow() {
+    JobApplication managedApp = entityManager.find(JobApplication.class, app1.getId());
+    Note toRemove = managedApp.getNotes().getFirst();
+    managedApp.removeNote(toRemove);
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(noteRepository.findByJobApplicationIdOrderByCreatedAtDesc(app1.getId())).hasSize(2);
+  }
+}

--- a/backend/src/test/java/com/jhub/backend/service/NoteServiceTest.java
+++ b/backend/src/test/java/com/jhub/backend/service/NoteServiceTest.java
@@ -1,0 +1,195 @@
+package com.jhub.backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.jhub.backend.dto.NoteCreateRequest;
+import com.jhub.backend.dto.NoteResponse;
+import com.jhub.backend.exception.ResourceNotFoundException;
+import com.jhub.backend.model.JobApplication;
+import com.jhub.backend.model.Note;
+import com.jhub.backend.model.User;
+import com.jhub.backend.model.enums.JobApplicationStatus;
+import com.jhub.backend.repository.JobApplicationRepository;
+import com.jhub.backend.repository.NoteRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NoteServiceTest {
+
+  @Mock private NoteRepository noteRepository;
+
+  @Mock private JobApplicationRepository jobApplicationRepository;
+
+  @InjectMocks private NoteService service;
+
+  private User user;
+  private UUID userId;
+  private UUID otherUserId;
+  private JobApplication application;
+  private UUID applicationId;
+  private Note note;
+  private UUID noteId;
+
+  @BeforeEach
+  void setUp() {
+    userId = UUID.randomUUID();
+    otherUserId = UUID.randomUUID();
+    user =
+        User.builder()
+            .email("test@example.com")
+            .password("password123")
+            .firstName("Test")
+            .lastName("User")
+            .build();
+    user.setId(userId);
+
+    applicationId = UUID.randomUUID();
+    application =
+        JobApplication.builder()
+            .user(user)
+            .company("Acme Corp")
+            .jobTitle("Software Engineer")
+            .status(JobApplicationStatus.APPLIED)
+            .dateApplied(LocalDate.of(2026, 1, 15))
+            .build();
+    application.setId(applicationId);
+
+    noteId = UUID.randomUUID();
+    note =
+        Note.builder()
+            .content("Spoke with recruiter")
+            .followUp(true)
+            .followUpDate(LocalDate.of(2026, 8, 1))
+            .build();
+    note.setId(noteId);
+    note.setCreatedAt(Instant.now());
+    note.setUpdatedAt(Instant.now());
+    application.addNote(note);
+  }
+
+  @Nested
+  class GetNotesForJobApplication {
+
+    @Test
+    void returnsNotesForOwnedApplication() {
+      when(jobApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+      when(noteRepository.findByJobApplicationIdOrderByCreatedAtDesc(applicationId))
+          .thenReturn(List.of(note));
+
+      List<NoteResponse> result = service.getNotesForJobApplication(userId, applicationId);
+
+      assertThat(result).hasSize(1);
+      assertThat(result.getFirst().content()).isEqualTo("Spoke with recruiter");
+      assertThat(result.getFirst().jobApplicationId()).isEqualTo(applicationId);
+    }
+
+    @Test
+    void throwsNotFoundWhenApplicationMissing() {
+      when(jobApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> service.getNotesForJobApplication(userId, applicationId))
+          .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void throwsNotFoundWhenApplicationOwnedByAnotherUser() {
+      when(jobApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+      assertThatThrownBy(() -> service.getNotesForJobApplication(otherUserId, applicationId))
+          .isInstanceOf(ResourceNotFoundException.class);
+      verify(noteRepository, never()).findByJobApplicationIdOrderByCreatedAtDesc(any());
+    }
+  }
+
+  @Nested
+  class CreateNote {
+
+    @Test
+    void createsNoteOnOwnedApplication() {
+      NoteCreateRequest request =
+          new NoteCreateRequest(
+              applicationId, "Follow up next week", true, LocalDate.of(2026, 8, 1));
+      when(jobApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+      when(noteRepository.save(any(Note.class)))
+          .thenAnswer(
+              invocation -> {
+                Note saved = invocation.getArgument(0);
+                saved.setId(UUID.randomUUID());
+                saved.setCreatedAt(Instant.now());
+                saved.setUpdatedAt(Instant.now());
+                return saved;
+              });
+
+      NoteResponse result = service.createNote(userId, request);
+
+      assertThat(result.content()).isEqualTo("Follow up next week");
+      assertThat(result.followUp()).isTrue();
+      assertThat(result.followUpDate()).isEqualTo(LocalDate.of(2026, 8, 1));
+      assertThat(result.jobApplicationId()).isEqualTo(applicationId);
+    }
+
+    @Test
+    void throwsNotFoundWhenApplicationOwnedByAnotherUser() {
+      NoteCreateRequest request = new NoteCreateRequest(applicationId, "Sneaky note", false, null);
+      when(jobApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+      assertThatThrownBy(() -> service.createNote(otherUserId, request))
+          .isInstanceOf(ResourceNotFoundException.class);
+      verify(noteRepository, never()).save(any());
+    }
+
+    @Test
+    void throwsNotFoundWhenApplicationMissing() {
+      NoteCreateRequest request = new NoteCreateRequest(applicationId, "Orphan note", false, null);
+      when(jobApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> service.createNote(userId, request))
+          .isInstanceOf(ResourceNotFoundException.class);
+      verify(noteRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  class DeleteNote {
+
+    @Test
+    void removesNoteFromOwnedApplication() {
+      when(noteRepository.findById(noteId)).thenReturn(Optional.of(note));
+
+      service.deleteNote(userId, noteId);
+
+      assertThat(application.getNotes()).doesNotContain(note);
+    }
+
+    @Test
+    void throwsNotFoundWhenNoteMissing() {
+      when(noteRepository.findById(noteId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> service.deleteNote(userId, noteId))
+          .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void throwsNotFoundWhenNoteOwnedByAnotherUser() {
+      when(noteRepository.findById(noteId)).thenReturn(Optional.of(note));
+
+      assertThatThrownBy(() -> service.deleteNote(otherUserId, noteId))
+          .isInstanceOf(ResourceNotFoundException.class);
+      assertThat(application.getNotes()).contains(note);
+    }
+  }
+}


### PR DESCRIPTION
Closes #40.

Implements the notes backend on top of the existing `Note` entity and `notes` table (V1 schema, V2 index). Follows the JobApplication layering: controller → service → repository, records for DTOs, constructor injection.

## Endpoints

- `POST /api/notes` — create a note (optional follow-up flag + date), 201
- `GET /api/notes/job-application/{id}` — list an application's notes, newest first
- `DELETE /api/notes/{id}` — delete via orphan removal, 204

## Security

- User id is always parsed from the JWT subject, never from the request
- Every operation verifies ownership through the parent job application; non-owned and missing resources both return 404 so resource existence is never revealed across accounts (same convention as `JobApplicationService`)
- Note content capped at 10,000 chars in the request DTO (the `TEXT` column is unbounded)
- A `followUpDate` without `followUp: true` is rejected to keep follow-up queries consistent

## Also Included

- `NoteRepository.findFollowUpsDueBetween(userId, from, to)` — user-scoped follow-up range query for the upcoming dashboard (#38), covered by integration tests

## Deviation From Issue

Notes are intentionally **not** embedded in `JobApplicationResponse`: it would force loading every note on the list endpoint (N+1) and duplicate what the dedicated notes endpoint serves. The frontend (#41) will fetch notes per application.

## Verification

- 23 new tests (service ownership/CRUD, controller status codes + validation, repository queries via Testcontainers); full suite: 86 tests, 0 failures
- Exercised live against a real Postgres: full note lifecycle plus cross-user create/list/delete attempts (all 404, no data leakage), unauthenticated access (401), and validation failures (400)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated note management for job applications.
  * Users can create notes with optional follow-up dates, view notes by application, and delete notes.
  * Added validation for required note details and follow-up information.
  * Notes are sorted by creation date, with follow-up dates supported.

* **Bug Fixes**
  * Restricted note access and deletion to the owning user.

* **Tests**
  * Added coverage for note creation, validation, retrieval, deletion, ownership, and follow-up filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->